### PR TITLE
Explicitly add Upstream and Downstream to the curriculum

### DIFF
--- a/docs/06-module-block-6/01-duration-terms.adoc
+++ b/docs/06-module-block-6/01-duration-terms.adoc
@@ -4,6 +4,7 @@
 |===
 
 === Begriffe und Konzepte
+* Upstream und Downstream
 * Shared Kernel, Customer/Supplier Teams, Open Host Service (vgl. Übersicht auf Seite 388 <<evans>>)
 * Domain Event als Kommunikationsmittel
 * Anticorruption-Layer
@@ -17,6 +18,7 @@
 |===
 
 === Terms and Principles
+* Upstream and Downstream
 * Shared Kernel, Customer/Supplier Teams, Open Host Service (cf. overview on page 388 <<evans>>)
 * Domain Event as means of communication
 * Anticorruption-Layer

--- a/docs/06-module-block-6/02-learning-goals.adoc
+++ b/docs/06-module-block-6/02-learning-goals.adoc
@@ -48,6 +48,13 @@ Dieser Block vermittelt Ansätze, mit denen die Konsistenz innerhalb eines Model
 ** Wenn Events trotz vorhandener Abhängigkeiten (z. B. innerhalb eines Bounded Contexts) eingesetzt werden, besteht das Risiko, dass dadurch die Abhängigkeiten nur versteckt werden und zur Laufzeit zu schwer nachvollziehbaren Kontrollflüssen führen.
 * Die TN sind in der Lage einen Event Store (vgl. Seite 539 <<vernon>>) einzusetzen, um es den Subscribern zu ermöglichen, fehlerhaft verarbeitete Events erneut zu verarbeiten.
 
+[[LZ-6-7]]
+==== LZ 6-7: Upstream und Downstream erkennen und einbeziehen können
+* Die TN verstehen, dass eine Downstream Gruppe von den Ergebnissen einer Upstream Gruppe abhängig ist
+* Die TN verstehen, dass eine Upstream Gruppe auch ohne die Downstream Gruppe erfolgreich sein kann
+* Die TN sind in der Lage den Sachverhalt auf einer Context Map zum Ausdruck zu bringen
+* Die TN kennen unterschiedliche Beispiele wie eine solche Abhängigkeit sich ausdrücken kann
+* Die TN verstehen wie die Domäne Einfluss auf die Entstehung von Upstream und Downstream Gruppen nimmt
 
 // end::DE[]
 
@@ -97,5 +104,13 @@ This section teaches approaches with which the consistency within a model can be
 * The course participants are able to assess opportunities and risks of Domain Events in this context:
 ** If events are used despite existing dependencies (e.g., within a Bounded Context), there is a risk that the dependencies will only be hidden, which could lead to control flows that are difficult to understand at runtime.
 * The course participants are able to use an event store (cf.: page 539 <<vernon>>) to allow Subscribers to reprocess events that were incorrectly processed.
+
+[[LG-6-7]]
+==== LG 6-7: Be able to recognize upstream and downstream relationships and their implications
+* The course participants understand that a downstream group is dependent on the results of an upstream group
+* The course participants understand that an upstream group can succeed without the downstream group
+* The course participants can communicate upstream and downstream Relationships on a context map
+* The course participants know examples how an upstream and downstream relationship might look like in practice
+* The course participants understand the role of the domain in the creation of upstream and downstream relationships
 
 // end::EN[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -37,6 +37,7 @@ This section contains references that are cited in the curriculum.
 **E**
 
 - [[[evans,Evans, E. (2003)]]] *Domain-Driven Design: Tacking Complexity In the Heart of Software*. Boston, MA, USA: Addison-Wesley Longman Publishing Co., Inc.
+- [[[evans,Evans, E. (2015)]]] *Domain-Driven Design Reference: Definitions and Pattern Summaries*. Von https://www.domainlanguage.com/ddd/reference/ abgerufen
 
 **F**
 


### PR DESCRIPTION
Hi,
As mentioned on OOP I created this short PR to explicitly add upstream and downstream and add the evans reference to the sources.

- Noah